### PR TITLE
fix: missing a hyphen

### DIFF
--- a/resume.tex
+++ b/resume.tex
@@ -179,7 +179,7 @@ GitHub: \MYhref{https://www.github.com/johndoe}{johndoe}
 \section{Summary}
 \resumeSubHeadingListStart
 \justifying
-Software Engineer with 2+ years of experience specializing in backend development in cloud infrastructure and distributed systems. Looking for Software Engineer positions, passionate about distributed systems and large scale infrastructure.
+Software Engineer with 2+ years of experience specializing in backend development in cloud infrastructure and distributed systems. Looking for Software Engineer positions, passionate about distributed systems and large-scale infrastructure.
 \resumeSubHeadingListEnd
 
 %-----------EXPERIENCE-----------------


### PR DESCRIPTION
It seems that "large scale" is missing a hyphen. Source: Grammarly.